### PR TITLE
Create a new SEG2 File from ObsPy data stream

### DIFF
--- a/pyseg2/binaryblocks.py
+++ b/pyseg2/binaryblocks.py
@@ -478,7 +478,7 @@ class FreeFormatSection:
     A group of strings that appear in the file header and in each trace header
     """
     parent: Union[TracePointerSubblock, TraceDescriptorSubBlock]
-    strings: Optional[List[Seg2String]] = None
+    strings: Optional[List[Seg2String]] = field(default_factory=list)
 
     @property
     def endian(self):

--- a/pyseg2/fromobspy.py
+++ b/pyseg2/fromobspy.py
@@ -1,0 +1,114 @@
+from pyseg2.seg2file import Seg2Trace, Seg2File
+from pyseg2.binaryblocks import FileDescriptorSubBlock, TraceDescriptorSubBlock, FreeFormatSection, TraceDataBlock, Seg2String
+from enum import Enum
+
+class SEG2Sorting(Enum):
+    AS_ACQUIRED = "AS_ACQUIRED"
+    CDP_GATHER = "CDP_GATHER"
+    CDP_STACK = "CDP_STACK"
+    COMMON_OFFSET = "COMMON_OFFSET"
+    COMMON_RECEIVER = "COMMON_RECEIVER"
+    COMMON_SOURCE = "COMMON_SOURCE"
+
+class SEG2Units(Enum):
+    FEET = "FEET"
+    METERS = "METERS"
+    INCHES = "INCHES"
+    CENTIMETERS = "CENTIMETERS"
+    NONE = "NONE"
+
+
+def pyseg2_from_obspy_stream(seg2file, obspy_stream, delay=0, stacks=1, line_id='', 
+                             source_x=0, units: str = SEG2Units.METERS.value, 
+                             sorting: str = SEG2Sorting.COMMON_SOURCE.value, company=''):
+    """
+    Populate seg2file structure with data and metadata from the Obspy stream.
+
+    Parameters:
+    -----------
+    seg2file : [type]
+        The SEG2 file structure to populate.
+    obspy_stream : obspy.Stream
+        The Obspy stream containing seismic trace data.
+    delay : int, optional
+        Delay applied to the traces, by default 0
+    stacks : int, optional
+        Number of stacks, by default 1
+    line_id : str, optional
+        Identifier for the seismic line, by default ''
+    source_x : int, optional
+        Source coordinate X, by default 0
+    units : str, optional
+        Units of measurement. Allowed values are:
+        FEET, METERS, INCHES, CENTIMETERS, NONE (defined in "SEG2Units" enum). Default is METERS.
+    sorting : str, optional
+        Sorting method applied to the traces. Available options are:
+        AS_ACQUIRED, CDP_GATHER, CDP_STACK, COMMON_OFFSET, COMMON_RECEIVER, COMMON_SOURCE  (defined in "SEG2Sorting" enum).
+        Default is COMMON_SOURCE.
+    company : str, optional
+        Company name metadata, by default ''
+
+    Raises:
+    -------
+    ValueError:
+        If 'sorting' or 'units' values are not among the allowed enum options.
+    """
+    try:
+        sorting = SEG2Sorting(sorting)
+    except ValueError:
+        raise ValueError(f"Invalid sorting method: {sorting}")
+
+    try:
+        units = SEG2Units(units)
+    except ValueError:
+        raise ValueError(f"Invalid units: {units}")
+
+    date = obspy_stream[0].stats.starttime.strftime("%d/%m/%Y")
+    time = obspy_stream[0].stats.starttime.strftime("%H:%M:%S")
+    Units = 'METERS'
+    DateString = Seg2String(parent = seg2file.free_format_section, text = f"ACQUISITION_DATE {date}")
+    TimeString = Seg2String(parent = seg2file.free_format_section, text = f"ACQUISITION_TIME {time}")
+    if company:
+        CompanyString = Seg2String(parent = seg2file.free_format_section, text = f"COMPANY {company}")
+        seg2file.free_format_section.strings.append(CompanyString)
+    SortingString = Seg2String(parent = seg2file.free_format_section, text = f"TRACE_SORT {sorting}")
+    UnitsString = Seg2String(parent = seg2file.free_format_section, text = f"UNITS {Units}")
+    seg2file.free_format_section.strings.append(DateString)
+    seg2file.free_format_section.strings.append(TimeString)
+    seg2file.free_format_section.strings.append(SortingString)
+    seg2file.free_format_section.strings.append(UnitsString)
+
+    traces = []
+    for i, trace in enumerate(obspy_stream):
+        trace_descriptor_subblock = TraceDescriptorSubBlock(parent=seg2file.file_descriptor_subblock)
+        trace_free_format_section = FreeFormatSection(parent=trace_descriptor_subblock)
+
+        DelayString = Seg2String(parent = trace_free_format_section, text = f"DELAY {str(delay)}")
+        trace_free_format_section.strings.append(DelayString) 
+        
+        if line_id:
+            LineIDString = Seg2String(parent = trace_free_format_section, text = f"LINE_ID {str(line_id)}")
+            trace_free_format_section.strings.append(LineIDString) 
+        
+        RxString = Seg2String(parent = trace_free_format_section, text = f"RECEIVER_LOCATION {str(trace.stats.distance)}")
+        trace_free_format_section.strings.append(RxString) 
+        
+        RxNoString = Seg2String(parent = trace_free_format_section, text = f"RECEIVER_STATION_NUMBER {str(trace.stats.station)}")
+        trace_free_format_section.strings.append(RxNoString) 
+        
+        SIntString = Seg2String(parent = trace_free_format_section, text = f"SAMPLE_INTERVAL {str(trace.stats.delta)}")
+        trace_free_format_section.strings.append(SIntString)
+
+        SxString = Seg2String(parent = trace_free_format_section, text = f"SOURCE_LOCATION {str(source_x)}")
+        trace_free_format_section.strings.append(SxString)
+
+        StackString = Seg2String(parent = trace_free_format_section, text = f"STACK {str((int)(stacks))}")
+        trace_free_format_section.strings.append(StackString)
+
+        trace_data_block = TraceDataBlock(parent=trace_descriptor_subblock)
+        trace_data_block.data = trace.data 
+        seg2trace = Seg2Trace(trace_descriptor_subblock, trace_free_format_section, trace_data_block)
+        
+        traces.append(seg2trace)
+
+    seg2file.seg2traces = traces

--- a/pyseg2/fromobspy.py
+++ b/pyseg2/fromobspy.py
@@ -65,14 +65,13 @@ def pyseg2_from_obspy_stream(seg2file, obspy_stream, delay=0, stacks=1, line_id=
 
     date = obspy_stream[0].stats.starttime.strftime("%d/%m/%Y")
     time = obspy_stream[0].stats.starttime.strftime("%H:%M:%S")
-    Units = 'METERS'
     DateString = Seg2String(parent = seg2file.free_format_section, text = f"ACQUISITION_DATE {date}")
     TimeString = Seg2String(parent = seg2file.free_format_section, text = f"ACQUISITION_TIME {time}")
     if company:
         CompanyString = Seg2String(parent = seg2file.free_format_section, text = f"COMPANY {company}")
         seg2file.free_format_section.strings.append(CompanyString)
-    SortingString = Seg2String(parent = seg2file.free_format_section, text = f"TRACE_SORT {sorting}")
-    UnitsString = Seg2String(parent = seg2file.free_format_section, text = f"UNITS {Units}")
+    SortingString = Seg2String(parent = seg2file.free_format_section, text = f"TRACE_SORT {sorting.value}")
+    UnitsString = Seg2String(parent = seg2file.free_format_section, text = f"UNITS {units.value}")
     seg2file.free_format_section.strings.append(DateString)
     seg2file.free_format_section.strings.append(TimeString)
     seg2file.free_format_section.strings.append(SortingString)

--- a/pyseg2/seg2file.py
+++ b/pyseg2/seg2file.py
@@ -232,8 +232,41 @@ class Seg2File:
 
         pyseg2_from_obspy_stream(self, obspy_stream, **kwargs)
 
+def create_demo_obspy_stream(num_traces: int = 5) -> obspy.core.stream.Stream:
+
+    num_samples = 1000
+    sampling_rate = 100.0  # Hz
+
+    traces = []
+    starttime = obspy.UTCDateTime.now()  # <-- use current time
+
+    for i in range(num_traces):
+        # Synthetic data: random noise
+        data = np.random.randn(num_samples).astype(np.float32)
+
+        trace = obspy.Trace(data=data)
+        trace.stats.station = f"STAT{i+1:02d}"
+        trace.stats.distance = f"{i}"
+        trace.stats.channel = f"Z"
+        trace.stats.sampling_rate = sampling_rate
+        trace.stats.starttime = starttime
+    
+        traces.append(trace)
+
+    st = obspy.Stream(traces=traces)
+    return st
 
 if __name__ == "__main__":
+    
+    # Demo of creating a SEG2 file from an ObsPy stream
+    st = create_demo_obspy_stream(12)
+    seg2 = Seg2File()
+    seg2.from_obspy(st, delay=-0.01,stacks=1, line_id='demo', source_x = 0, sorting = "AS_ACQUIRED", company='Demo Company')
+    with open('test.dat', 'wb') as fil:
+        fil.write(seg2.pack())
+    
+    """
+    # Demo of loading a SEG2 file and writing back a modified file
     print('load toto')
     seg2 = Seg2File()
     with open('./toto.seg2', 'rb') as fid:
@@ -251,6 +284,9 @@ if __name__ == "__main__":
         seg2re.load(fid)
 
     print(seg2re.seg2traces[0].trace_free_format_section)
+
+    """
+
 
     # exit()
     #

--- a/pyseg2/seg2file.py
+++ b/pyseg2/seg2file.py
@@ -30,6 +30,7 @@ Warning:
 from typing import List
 from dataclasses import dataclass
 import numpy as np
+import obspy
 
 from pyseg2.binaryblocks import \
     FileDescriptorSubBlock, TracePointerSubblock, \
@@ -219,6 +220,17 @@ class Seg2File:
         from pyseg2.toobspy import pyseg2_to_obspy_stream
 
         return pyseg2_to_obspy_stream(self, **kwargs)
+
+    def from_obspy(self, obspy_stream: obspy.core.stream.Stream, **kwargs):
+        """
+
+        :return :
+        """
+        #imported here to avoid circular imports
+        # print(kwargs)
+        from pyseg2.fromobspy import pyseg2_from_obspy_stream
+
+        pyseg2_from_obspy_stream(self, obspy_stream, **kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a new method for populatign teh Seg2file object with data and metadata form an ObsPy stream. 
This allows the file to be written using the existing seg2.pack() method. Users will need only four lines to write their ObsPy data to a seg2 file:

```
seg2 = Seg2File()
seg2.from_obspy(st)
with open('test.dat', 'wb') as fil:
    fil.write(seg2.pack())
``` 
The following parameters are created directly form teh obspy stream:
- Sample interval (per trace)
- distance (per trace)
- station name/ID (per trace)
- acquisition date (extracted from first trace to put in file header)
- acquisition time (extracted from first trace to put in file header)

The from_obspy method can take additional metadata as user inputs including (defaults are defined for all of these):
- units (allowed values defined in an enums and checked)
- trace sorting (allowed vlaues defined in an enum and checked)
- company name
- start time delay (set on every trace)
- line name/id (set on every trace if provided)
- source location (x coordinate only)
- number of stacks (1 is assumed if not provided)

I've added a method to create a demo obspy stream and put code to use this in the if __name__ == "__main__": method so the new features can be easily tested/demonstrated.
