### PR TITLE
Bug Fix: End of Free Text Blocks

### DIFF
--- a/pyseg2/binaryblocks.py
+++ b/pyseg2/binaryblocks.py
@@ -496,7 +496,7 @@ class FreeFormatSection:
         """actual number of bytes (packing)"""
         assert self.strings is not None
         string: Seg2String
-        ans = np.sum([string.number_of_bytes() for string in self.strings])
+        ans = np.sum([string.number_of_bytes() for string in self.strings])+2 # add two more bytes to store a zero offset after the last string (required by seg2 definition)
         ans = int(np.ceil(ans / 4.) * 4.)
         return ans
 


### PR DESCRIPTION
There should be a uint16 zero after the last free text strig. Extended the byte sum by 2 ensures this is always true.